### PR TITLE
Landing Page photo blurred and pixelated on IPad Pro

### DIFF
--- a/client/Components/landing_page_new/landing_page.css
+++ b/client/Components/landing_page_new/landing_page.css
@@ -185,7 +185,7 @@
   background-attachment: fixed;
 }
 
-@media only screen and (max-width: 1024px) {
+@media only screen and (max-width: 1366px) {
   .landing_1 {
     background-attachment: initial;
   }


### PR DESCRIPTION
https://app.asana.com/0/406198158267710/571527480257481/f

Changed the following setting to detach the background-attachment to cater iPad Pro horizontal resolution